### PR TITLE
GSoC2020 Smart Pointers Fix in Classification and PSP

### DIFF
--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -166,7 +166,7 @@ private:
     {
       CGAL::Real_timer t;
       t.start();
-      neighborhood = std::unique_ptr<Neighborhood>(new Neighborhood (input));
+      neighborhood = std::make_unique<Neighborhood>(input);
       t.stop();
 
       CGAL_CLASSIFICATION_CERR << "Neighborhood computed in " << t.time() << " second(s)" << std::endl;
@@ -174,10 +174,9 @@ private:
       t.reset();
       t.start();
 
-      eigen = std::unique_ptr<Local_eigen_analysis> (new Local_eigen_analysis
-        (Local_eigen_analysis::create_from_face_graph
+      eigen = std::make_unique<Local_eigen_analysis> (Local_eigen_analysis::create_from_face_graph
          (input, neighborhood->n_ring_neighbor_query(nb_scale + 1),
-          ConcurrencyTag(), DiagonalizeTraits())));
+          ConcurrencyTag(), DiagonalizeTraits()));
       float mrange = eigen->mean_range();
       if (this->voxel_size < 0)
         this->voxel_size = mrange;
@@ -188,22 +187,14 @@ private:
       t.start();
 
       if (lower_grid == nullptr)
-        grid = std::unique_ptr<Planimetric_grid> (new Planimetric_grid (range, point_map, bbox, this->voxel_size));
+        grid = std::make_unique<Planimetric_grid> (range, point_map, bbox, this->voxel_size);
       else
-        grid = std::unique_ptr<Planimetric_grid> (new Planimetric_grid(lower_grid));
+        grid = std::make_unique<Planimetric_grid> (lower_grid);
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();
     }
-    ~Scale()
-    {
 
-    }
-
-    void reduce_memory_footprint(bool delete_neighborhood)
-    {
-
-    }
 
     float grid_resolution() const { return voxel_size; }
     float radius_neighbors() const { return voxel_size * 3; }
@@ -257,7 +248,7 @@ public:
 
     m_scales.reserve (nb_scales);
 
-    m_scales.push_back (std::unique_ptr<Scale>( new Scale (m_input, m_range, m_point_map, m_bbox, voxel_size, 0)));
+    m_scales.push_back (std::make_unique<Scale>(m_input, m_range, m_point_map, m_bbox, voxel_size, 0));
 
     if (voxel_size == -1.f)
       voxel_size = m_scales[0]->grid_resolution();
@@ -265,7 +256,7 @@ public:
     for (std::size_t i = 1; i < nb_scales; ++ i)
     {
       voxel_size *= 2;
-      m_scales.push_back (std::unique_ptr<Scale>( new Scale (m_input, m_range, m_point_map, m_bbox, voxel_size, i, m_scales[i-1]->grid)));
+      m_scales.push_back (std::make_unique<Scale>(m_input, m_range, m_point_map, m_bbox, voxel_size, i, m_scales[i-1]->grid));
     }
     t.stop();
     CGAL_CLASSIFICATION_CERR << "Scales computed in " << t.time() << " second(s)" << std::endl;
@@ -275,15 +266,8 @@ public:
   /// @}
 
   /// \cond SKIP_IN_MANUAL
-  virtual ~Mesh_feature_generator()
-  {
 
-  }
 
-  void reduce_memory_footprint()
-  {
-
-  }
   /// \endcond
 
 

--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -161,7 +161,7 @@ private:
            PointMap point_map,
            const Iso_cuboid_3& bbox, float voxel_size,
            std::size_t nb_scale,
-           Planimetric_grid* lower_grid = nullptr)
+           std::unique_ptr<Planimetric_grid> &lower_grid = nullptr)
       : voxel_size (voxel_size)
     {
       CGAL::Real_timer t;
@@ -189,7 +189,7 @@ private:
       if (lower_grid == nullptr)
         grid = std::make_unique<Planimetric_grid> (range, point_map, bbox, this->voxel_size);
       else
-        grid.reset(lower_grid);
+        grid = std::unique_ptr<Planimetric_grid>(lower_grid.get());
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();

--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -265,11 +265,6 @@ public:
 
   /// @}
 
-  /// \cond SKIP_IN_MANUAL
-
-
-  /// \endcond
-
 
   /// \name Feature Generation
   /// @{

--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -161,7 +161,7 @@ private:
            PointMap point_map,
            const Iso_cuboid_3& bbox, float voxel_size,
            std::size_t nb_scale,
-           std::unique_ptr<Planimetric_grid> &lower_grid = nullptr)
+           std::unique_ptr<Planimetric_grid> const &lower_grid = nullptr)
       : voxel_size (voxel_size)
     {
       CGAL::Real_timer t;

--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -161,7 +161,7 @@ private:
            PointMap point_map,
            const Iso_cuboid_3& bbox, float voxel_size,
            std::size_t nb_scale,
-           std::unique_ptr<Planimetric_grid> const &lower_grid = nullptr)
+           Planimetric_grid* lower_grid = nullptr)
       : voxel_size (voxel_size)
     {
       CGAL::Real_timer t;
@@ -256,7 +256,7 @@ public:
     for (std::size_t i = 1; i < nb_scales; ++ i)
     {
       voxel_size *= 2;
-      m_scales.push_back (std::make_unique<Scale>(m_input, m_range, m_point_map, m_bbox, voxel_size, i, m_scales[i-1]->grid));
+      m_scales.push_back (std::make_unique<Scale>(m_input, m_range, m_point_map, m_bbox, voxel_size, i, (m_scales[i-1]->grid).get()));
     }
     t.stop();
     CGAL_CLASSIFICATION_CERR << "Scales computed in " << t.time() << " second(s)" << std::endl;

--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -189,7 +189,7 @@ private:
       if (lower_grid == nullptr)
         grid = std::make_unique<Planimetric_grid> (range, point_map, bbox, this->voxel_size);
       else
-        grid = std::unique_ptr<Planimetric_grid>(lower_grid.get());
+        grid = std::unique_ptr<Planimetric_grid>(lower_grid);
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();

--- a/Classification/include/CGAL/Classification/Mesh_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Mesh_feature_generator.h
@@ -189,7 +189,7 @@ private:
       if (lower_grid == nullptr)
         grid = std::make_unique<Planimetric_grid> (range, point_map, bbox, this->voxel_size);
       else
-        grid = std::make_unique<Planimetric_grid> (lower_grid);
+        grid.reset(lower_grid);
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -165,9 +165,9 @@ private:
       CGAL::Real_timer t;
       t.start();
       if (lower_grid == nullptr)
-        neighborhood = std::unique_ptr<Neighborhood>( new Neighborhood (input, point_map));
+        neighborhood = std::make_unique<Neighborhood>(input, point_map);
       else
-        neighborhood = std::unique_ptr<Neighborhood>( new Neighborhood (input, point_map, voxel_size));
+        neighborhood = std::make_unique<Neighborhood>(input, point_map, voxel_size);
       t.stop();
 
       if (lower_grid == nullptr)
@@ -178,9 +178,8 @@ private:
       t.reset();
       t.start();
 
-      eigen = std::unique_ptr<Local_eigen_analysis>( new Local_eigen_analysis
-        (Local_eigen_analysis::create_from_point_set
-         (input, point_map, neighborhood->k_neighbor_query(12), ConcurrencyTag(), DiagonalizeTraits())));
+      eigen = std::make_unique<Local_eigen_analysis>(Local_eigen_analysis::create_from_point_set
+         (input, point_map, neighborhood->k_neighbor_query(12), ConcurrencyTag(), DiagonalizeTraits()));
 
       float range = eigen->mean_range();
       if (this->voxel_size < 0)
@@ -192,9 +191,9 @@ private:
       t.start();
 
       if (lower_grid == nullptr)
-        grid = std::unique_ptr<Planimetric_grid>( new Planimetric_grid (input, point_map, bbox, this->voxel_size));
+        grid = std::make_unique<Planimetric_grid>(input, point_map, bbox, this->voxel_size);
       else
-        grid = std::unique_ptr<Planimetric_grid>( new Planimetric_grid(lower_grid));
+        grid = std::make_unique<Planimetric_grid>(lower_grid);
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();
@@ -252,7 +251,7 @@ public:
 
     m_scales.reserve (nb_scales);
 
-    m_scales.push_back (std::unique_ptr<Scale>( new Scale (m_input, m_point_map, m_bbox, voxel_size)));
+    m_scales.push_back (std::make_unique<Scale>(m_input, m_point_map, m_bbox, voxel_size));
 
     if (voxel_size == -1.f)
       voxel_size = m_scales[0]->grid_resolution();
@@ -260,7 +259,7 @@ public:
     for (std::size_t i = 1; i < nb_scales; ++ i)
     {
       voxel_size *= 2;
-      m_scales.push_back (std::unique_ptr<Scale>( new Scale (m_input, m_point_map, m_bbox, voxel_size, m_scales[i-1]->grid)));
+      m_scales.push_back (std::make_unique<Scale>(m_input, m_point_map, m_bbox, voxel_size, m_scales[i-1]->grid));
     }
     t.stop();
     CGAL_CLASSIFICATION_CERR << "Scales computed in " << t.time() << " second(s)" << std::endl;
@@ -270,10 +269,7 @@ public:
   /// @}
 
   /// \cond SKIP_IN_MANUAL
-  virtual ~Point_set_feature_generator()
-  {
-    clear();
-  }
+
 
   /// \endcond
 
@@ -435,11 +431,6 @@ public:
 
 
 private:
-
-  void clear()
-  {
-
-  }
 
 #ifdef CGAL_CLASSIFICATION_USE_GRADIENT_OF_FEATURE
   void generate_gradient_features(Feature_set& features)

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -198,10 +198,6 @@ private:
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();
     }
-    ~Scale()
-    {
-
-    }
 
     float grid_resolution() const { return voxel_size; }
     float radius_neighbors() const { return voxel_size * 3; }

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -193,7 +193,7 @@ private:
       if (lower_grid == nullptr)
         grid = std::make_unique<Planimetric_grid>(input, point_map, bbox, this->voxel_size);
       else
-        grid = std::make_unique<Planimetric_grid>(lower_grid);
+        grid.reset(lower_grid);
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -159,7 +159,7 @@ private:
 
     Scale (const PointRange& input, PointMap point_map,
            const Iso_cuboid_3& bbox, float voxel_size,
-           Planimetric_grid* lower_grid = nullptr)
+           std::unique_ptr<Planimetric_grid> &lower_grid = nullptr)
       : voxel_size (voxel_size)
     {
       CGAL::Real_timer t;
@@ -193,7 +193,7 @@ private:
       if (lower_grid == nullptr)
         grid = std::make_unique<Planimetric_grid>(input, point_map, bbox, this->voxel_size);
       else
-        grid.reset(lower_grid);
+        grid = std::unique_ptr<Planimetric_grid>(lower_grid.get());
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -159,7 +159,7 @@ private:
 
     Scale (const PointRange& input, PointMap point_map,
            const Iso_cuboid_3& bbox, float voxel_size,
-           std::unique_ptr<Planimetric_grid> const &lower_grid = nullptr)
+           1Planimetric_grid* lower_grid = nullptr)
       : voxel_size (voxel_size)
     {
       CGAL::Real_timer t;
@@ -193,7 +193,7 @@ private:
       if (lower_grid == nullptr)
         grid = std::make_unique<Planimetric_grid>(input, point_map, bbox, this->voxel_size);
       else
-        grid = std::unique_ptr<Planimetric_grid>(lower_grid.get());
+        grid = std::unique_ptr<Planimetric_grid>(lower_grid);
       t.stop();
       CGAL_CLASSIFICATION_CERR << "Planimetric grid computed in " << t.time() << " second(s)" << std::endl;
       t.reset();
@@ -255,7 +255,7 @@ public:
     for (std::size_t i = 1; i < nb_scales; ++ i)
     {
       voxel_size *= 2;
-      m_scales.push_back (std::make_unique<Scale>(m_input, m_point_map, m_bbox, voxel_size, m_scales[i-1]->grid));
+      m_scales.push_back (std::make_unique<Scale>(m_input, m_point_map, m_bbox, voxel_size, (m_scales[i-1]->grid).get()));
     }
     t.stop();
     CGAL_CLASSIFICATION_CERR << "Scales computed in " << t.time() << " second(s)" << std::endl;

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -159,7 +159,7 @@ private:
 
     Scale (const PointRange& input, PointMap point_map,
            const Iso_cuboid_3& bbox, float voxel_size,
-           std::unique_ptr<Planimetric_grid> &lower_grid = nullptr)
+           std::unique_ptr<Planimetric_grid> const &lower_grid = nullptr)
       : voxel_size (voxel_size)
     {
       CGAL::Real_timer t;

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -159,7 +159,7 @@ private:
 
     Scale (const PointRange& input, PointMap point_map,
            const Iso_cuboid_3& bbox, float voxel_size,
-           1Planimetric_grid* lower_grid = nullptr)
+           Planimetric_grid* lower_grid = nullptr)
       : voxel_size (voxel_size)
     {
       CGAL::Real_timer t;

--- a/Classification/include/CGAL/Classification/Point_set_feature_generator.h
+++ b/Classification/include/CGAL/Classification/Point_set_feature_generator.h
@@ -268,11 +268,6 @@ public:
 
   /// @}
 
-  /// \cond SKIP_IN_MANUAL
-
-
-  /// \endcond
-
   /// \name Feature Generation
   /// @{
 

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
@@ -87,7 +87,7 @@ public:
         *m_interrupted = true;
       if (*m_interrupted)
         return;
-      std::this_thread_sleep_for (std::chrono::microseconds(10));
+      std::this_thread::sleep_for (std::chrono::microseconds(10));
     }
     m_callback (1.);
   }

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Parallel_callback.h
@@ -17,6 +17,9 @@
 #include <functional>
 
 #include <memory>
+#include <atomic>
+#include <thread>
+#include <chrono>
 
 #include <CGAL/thread.h>
 
@@ -27,11 +30,11 @@ namespace internal {
 class Parallel_callback
 {
   const std::function<bool(double)>& m_callback;
-  std::shared_ptr<cpp11::atomic<std::size_t> > m_advancement;
-  std::shared_ptr<cpp11::atomic<bool> > m_interrupted;
+  std::shared_ptr<std::atomic<std::size_t> > m_advancement;
+  std::shared_ptr<std::atomic<bool> > m_interrupted;
   std::size_t m_size;
   bool m_creator;
-  std::unique_ptr<cpp11::thread> m_thread;
+  std::unique_ptr<std::thread> m_thread;
 
   // assignment operator shouldn't be used (m_callback is const ref)
   Parallel_callback& operator= (const Parallel_callback&)
@@ -45,17 +48,15 @@ public:
                      std::size_t advancement = 0,
                      bool interrupted = false)
     : m_callback (callback)
-    , m_advancement (new cpp11::atomic<std::size_t>())
-    , m_interrupted (new cpp11::atomic<bool>())
+    , m_advancement (new std::atomic<std::size_t>())
+    , m_interrupted (new std::atomic<bool>())
     , m_size (size)
     , m_creator (true)
-    , m_thread (nullptr)
   {
-    // cpp11::atomic only has default constructor, initialization done in two steps
     *m_advancement = advancement;
     *m_interrupted = interrupted;
     if (m_callback)
-      m_thread = std::unique_ptr<cpp11::thread>( new cpp11::thread (*this));
+      m_thread = std::make_unique<std::thread>(*this);
   }
 
   Parallel_callback (const Parallel_callback& other)
@@ -64,19 +65,14 @@ public:
     , m_interrupted (other.m_interrupted)
     , m_size (other.m_size)
     , m_creator (false)
-    , m_thread (nullptr)
+
   {
 
   }
 
 
-  ~Parallel_callback ()
-  {
-
-  }
-
-  cpp11::atomic<std::size_t>& advancement() { return *m_advancement; }
-  cpp11::atomic<bool>& interrupted() { return *m_interrupted; }
+  std::atomic<std::size_t>& advancement() { return *m_advancement; }
+  std::atomic<bool>& interrupted() { return *m_interrupted; }
   void join()
   {
     if (m_thread != nullptr)
@@ -91,7 +87,7 @@ public:
         *m_interrupted = true;
       if (*m_interrupted)
         return;
-      cpp11::sleep_for (0.00001);
+      std::this_thread_sleep_for (std::chrono::microseconds(10));
     }
     m_callback (1.);
   }


### PR DESCRIPTION
This PR solves #4590 by using smart pointers in place of raw pointers in two packages `Classification` and `Point_set_processing_3`.

## Summary of Changes

In `Classification/mesh_feature_generator.h` and `Classification/Point_set_feature_generator` `std::unique_ptr` replaces raw pointers and in `Point_set_processing_3/parallel_callback.h` both `unique_ptr` and `std::shared_ptr` are used in place of raw pointers.

## Release Management

* Affected package(s): `Classification` and `Point_set_processing_3`
* Issue(s) solved (if any): fix #4590
* Feature/Small Feature (if any): enhancement


